### PR TITLE
pbsv call doesn't support gzip compression for vcf output

### DIFF
--- a/modules/variant_calling/structural/pbsv.j2
+++ b/modules/variant_calling/structural/pbsv.j2
@@ -3,7 +3,7 @@
 {%- set bam %}temp/{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}/{{ sample.name }}.{{ aligner }}.bam{% endset %}
 {%- set temp_dir %}temp/{{ sample.gltype }}/constitutional_structural_calls/pbsv/{{ sample.name }}_{{ aligner }}{% endset %}
 {%- set results_dir %}{{ sample.gltype }}/constitutional_structural_calls/pbsv/{{ sample.name }}_{{ aligner }}{% endset %}
-{%- set all_vcf %}{{ results_dir }}/{{ sample.name }}.{{ aligner }}.pbsv.all.vcf.gz{% endset %}
+{%- set all_vcf %}{{ results_dir }}/{{ sample.name }}.{{ aligner }}.pbsv.all.vcf{% endset %}
 {%- set pass_vcf %}{{ results_dir }}/{{ sample.name }}.{{ aligner }}.pbsv.pass.vcf.gz{% endset %}
 
 - name: pbsv_{{ sample.name }}_{{ aligner }}


### PR DESCRIPTION
Only removed the ".gz" extension because pbsv call complains that it doesn't like it.